### PR TITLE
normalise Bach/Lehman 1722 and add Bach/Lehman Chorale

### DIFF
--- a/res/values/help_strings.xml
+++ b/res/values/help_strings.xml
@@ -121,10 +121,11 @@
 	
 	<string name="temp_notes">\nNotes on the included Default Temperaments</string>
 	<string name="temp_notes_info">This is just a little bit of info about some of the included temperaments.</string>
-	<string name="temp_notes_lb">\nLehman-Bach</string>
+	<string name="temp_notes_lb">\nBach/Lehman</string>
 	<string name="temp_notes_lb_info">This is a temperament that Bradley Lehman \'uncovered\' while examining Bach\'s
 	    doodles on his title page to the Well-Tempered Clavier. It was fresh and all the rage in 2005 when the
-	    original, command-line TTuner was created. You can read more about it at his website:</string>
+	    original, command-line TTuner was created. The \'Chorale\' flavour is intended for modern issues of pieces
+	    which have been transposed from Chorton to Cammerton. You can read more about it at his website:</string>
 	<string name="temp_notes_larips">http://www.LaripS.com</string>
 	<string name="temp_notes_wsw">\nWoods So Wild</string>
 	<string name="temp_notes_wsw_info">

--- a/src/com/thefourthspecies/ttuner/model/Registry.java
+++ b/src/com/thefourthspecies/ttuner/model/Registry.java
@@ -52,12 +52,12 @@ public class Registry {
 		addDefaultTemperament("Bach/Lehman 1722",
 				"C = F-1/6P, G = C-1/6P, D = G-1/6P, A = D-1/6P, " +
 				"E = A-1/6P, B = E, F# = B, C# = F#, G# = C#-1/12P, " +
-				"D# = G#-1/12P, A# = D#-1/12P, F = Bb+1/12P");
+				"D# = G#-1/12P, A# = D#-1/12P");
 
 		addDefaultTemperament("Bach/Lehman Chorale",
 				"D = G-1/6P, A = D-1/6P, E = A-1/6P, B = E-1/6P, " +
 				"F# = B-1/6P, C# = F#, G# = C#, D# = G#, Bb = Eb-1/12P, " +
-				"F = Bb-1/12P, C = F-1/12P, G = C+1/12P");
+				"F = Bb-1/12P, C = F-1/12P");
 		
 		addDefaultTemperament("Meantone, 1/4 Comma",
 				"A = F, Bb = D, B = G, B= E-1/4S, C = E, C# = A, C#= F#-1/4S, D = F#, " +

--- a/src/com/thefourthspecies/ttuner/model/Registry.java
+++ b/src/com/thefourthspecies/ttuner/model/Registry.java
@@ -49,9 +49,15 @@ public class Registry {
 				"C=E, C=G-1/4S, G=D-1/4S, D=A-1/4S, A=E-1/4S, " +
 				"E=B, B=F#, Db=Ab, Ab=Eb, Eb=Bb, Bb=F, F=C");
 		
-		addDefaultTemperament("Lehman-Bach",
-				"A = E-1/6P, E = B, D = A-1/6P, G = D-1/6P, C = G-1/6P, F = C-1/6P, " +
-				"Bb = F+1/12P, Eb = Ab-1/12P, Ab = C#-1/12P, F# = B, C# = F#");
+		addDefaultTemperament("Bach/Lehman 1722",
+				"C = F-1/6P, G = C-1/6P, D = G-1/6P, A = D-1/6P, " +
+				"E = A-1/6P, B = E, F# = B, C# = F#, G# = C#-1/12P, " +
+				"D# = G#-1/12P, A# = D#-1/12P, F = Bb+1/12P");
+
+		addDefaultTemperament("Bach/Lehman Chorale",
+				"D = G-1/6P, A = D-1/6P, E = A-1/6P, B = E-1/6P, " +
+				"F# = B-1/6P, C# = F#, G# = C#, D# = G#, Bb = Eb-1/12P, " +
+				"F = Bb-1/12P, C = F-1/12P, G = C+1/12P");
 		
 		addDefaultTemperament("Meantone, 1/4 Comma",
 				"A = F, Bb = D, B = G, B= E-1/4S, C = E, C# = A, C#= F#-1/4S, D = F#, " +


### PR DESCRIPTION
This commit “normalises” Bach/Lehman 1722 according to a table I created from Lehman’s instructions from his website; my notes on that follow below.

It also adds the somewhat lesser, but still used (e.g. for [BWV 140](http://www.bach-cantatas.com/BWV140-D7.htm) which originally was a full tone higher), Bach/Lehman Chorale variant.

My notes on that temperament follow:

    Create "Bach/Lehman 1722" as a custom temperament.
    Start tuning from C, if possible.
    Offsets keeping A4 constant:
      C (+5.9), C♯ (+3.9), D (+2), E♭ (+3.9), E (-2), F (+7.8),
       F♯ (+2), G (+3.9), G♯ (+3.9), A (0), B♭ (+3.9), B (0).
    You end up with: F-C-G-D-A-E as they are in Vallotti ("1/6 comma" each);
     E-B-F♯-C♯ pure; C♯-G♯-D♯-A♯ very gently tempered ("1/12 comma" each);
     A♯-F leftover is also gently tempered, but happens to be wide.
      (pythagoräïsches Komma: 23.46 cent)
       Vallottis Temperatur besteht aus sechs um 1/6 pythagoräisches Komma
       temperierten Quinten von 698 Cent (F–C–G–D–A–E–H) und aus sechs
       reinen Quinten, die 702 Cent entsprechen (H–Fis–Cis–Gis/As–Es–B–F).
    Chorale: 1 Ton hoch, also: G-D-A-E-B-F♯ 1/6 comma each; F♯-C♯-G♯-D♯ pure;
     E♭-B♭-F-C 1/12 comma each; very slightly wide (but nearly pure) C-G resulting.
     Offsets from A:
      C (0), C♯ (-3.9), D (+2), E♭ (0), E (-1.9), F (0),
       F♯ (-5.9), G (+3.9), G♯ (-1.9), A (0), B♭ (0), B (-3.9).
    
    F   -2792.2     F-C   698.1     698 (-⅙,)                       -2800   +7.8
    C   -2094.1     C-G   698       698 (-⅙,)                       -2100   +5.9
    G   -1396.1     G-D   698.1     698 (-⅙,)                       -1400   +3.9
    D   -698        D-A   698       698 (-⅙,)                       -700    +2.0
    A   0           A-E   698       698 (-⅙,)                       0       ±0.0
    E   698         E-B   702       702 (reine Stimmung)            700     -2.0
    B   1400        B-F♯  702       702 (reine Stimmung)            1400    ±0.0
    F♯  2102        F♯-C♯ 701.9     702 (reine Stimmung)            2100    +2.0
    C♯  2803.9      C♯-G♯ 700       700 (-1/12,)                    2800    +3.9
    G♯  3503.9      G♯-D♯ 700       700 (gleichstufige Stimmung)    3500    +3.9
    D♯  4203.9      D♯-A♯ 700       700 (-1/12,)                    4200    +3.9
    A♯  4903.9      B♭-F  703.9     704 (+1/12,)                    4900    +3.9
    (F) 5607.8, ab initio 8400 = 7 Oktaven
    
    Chorale konstruïert:
    
    G   -1396.1     G-D   698.1     698 (-⅙,)                       -1400   +3.9
    D   -698        D-A   698       698 (-⅙,)                       -700    +2.0
    A   0           A-E   698.1     698 (-⅙,)                       0       ±0.0
    E   698.1       E-B   698       698 (-⅙,)                       700     -1.9
    B   1396.1      B-F♯  698       698 (-⅙,)                       1400    -3.9
    F♯  2094.1      F♯-C♯ 702       702 (reine Stimmung)            2100    -5.9
    C♯  2796.1      C♯-G♯ 702       702 (reine Stimmung)            2800    -3.9
    G♯  3498.1      G♯-D♯ 701.9     702 (reine Stimmung)            3500    -1.9
    D♯  4200        E♭-B♭ 700       700 (-1/12,)                    4200    ±0.0
    B♭  4900        B♭-F  700       700 (gleichstufige Stimmung)    4900    ±0.0
    F   5600        F-C   700       700 (-1/12,)                    5600    ±0.0
    C   6300        C-G   703.9     704 (+1/12,)                    6300    ±0.0
    (G) 7003.9, ab initio 8400 = 7 Oktaven

Your mileage may vary, but you might still wish to apply this.